### PR TITLE
resolve issue #715

### DIFF
--- a/static/assets/styles/main.css
+++ b/static/assets/styles/main.css
@@ -127,7 +127,7 @@ body {
 .fixed-nav-bar-right .navbar-link {
   margin-left: 10px;
   text-transform: uppercase;
-  font-size: 2.5vh;
+  font-size: 14px;
   cursor: pointer;
   color: var(--text-primary);
   font-weight: 800;
@@ -206,12 +206,12 @@ body {
   }
 }
 img {
-  width: 6vh;
+  width: 48px;
   padding-top: 5px;
 }
 @media (orientation: portrait) {
   img {
-    width: 6vw;
+    width: 24px;
   }
 }
 


### PR DESCRIPTION
This PR resolves issue #715 where the text is too small when the browser window is really short. 

You could use `vw` instead of `vh` if you still want it to scale dynamically. 
* vh stands for Viewport **Height**.
* vw stands for Viewport **Width**.