### PR TITLE
removed error

### DIFF
--- a/static/assets/json/g.json
+++ b/static/assets/json/g.json
@@ -1485,9 +1485,7 @@
     "name": "Taming.io",
     "link": "https://taming.io/",
     "image": "/assets/media/icons/tamingio.webp",
-    "categories": ["all"],
-    "error": "true",
-    "say": "Taming.io is currently broken on the proxy and will crash Interstellar when attempted to load."
+    "categories": ["all"]
   },
   {
     "name": "Temple of Boom",


### PR DESCRIPTION
there was a popup saying taming.io would crash interstellar, but it has been fixed according to this guy:
![image](https://github.com/UseInterstellar/Interstellar/assets/132697706/30df0a41-8d36-484a-a1a9-4fe9fa6584ba)
