### PR TITLE
fix: tab titles can be nothing, making tabs unclickable

### DIFF
--- a/static/assets/js/t.js
+++ b/static/assets/js/t.js
@@ -81,7 +81,7 @@ document.addEventListener("DOMContentLoaded", event => {
     newIframe.addEventListener("load", () => {
       const title = newIframe.contentDocument.title;
       if (title.length <= 1) {
-        tabTitle.textContent = "";
+        tabTitle.textContent = "Tab";
       } else {
         tabTitle.textContent = title;
       }


### PR DESCRIPTION
fixes https://discord.com/channels/938658733788131399/1308176571542011914/1329989687929995296

bug essentially makes tabs unclickable by forcing you to close them anytime you click on them...this fixes that

you could also make the tab part of the URL, but:
1. I don't think this happens often enough for it to matter
2. Which part of the URL would be the most useful is subjective
3. "Tab" is a short reference

bubbo friend me on discord >:(