### PR TITLE
fix koyeb deployments (update pnpm lockfile)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,7 +24,7 @@ importers:
         specifier: ^16.4.7
         version: 16.4.7
       express:
-        specifier: ^4.21.1
+        specifier: ^4.21.2
         version: 4.21.2
       express-basic-auth:
         specifier: ^1.2.1


### PR DESCRIPTION
closes #982 #955 - fully fixes koyeb deployment

cause of error (from #982) - pnpm lockfile is outdated

next time you update deps someone get on the cli and run `pnpm i`

<img width="446" alt="Screenshot 2025-01-17 at 10 52 10 PM" src="https://github.com/user-attachments/assets/477b53f0-2db0-4cbe-9e89-efafba100e06" />

test using my PR branch:

<img width="789" alt="Screenshot 2025-01-17 at 10 52 57 PM" src="https://github.com/user-attachments/assets/0841672f-ec44-4334-9664-0c5b0c1606e4" />
